### PR TITLE
Update with more configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,46 @@
 
 # Docker Compose Live Reloader
 
-This docker-compose pattern, aims to provide plug and play live reloading functionality to docker-compose stacks.
+This docker-compose pattern, aims to provide plug and play live reloading functionality
+to docker-compose stacks.
 
 A simple use case scenario for using this is the following:
 
-You have a stack of a web proxy, web server and a database all together containerized and configured as services in docker-compose for easy deployment. To develop locally, you make the changes and run `docker-compose up` to inspect what has changed. You realise that you have do make additional changes but now you need to restart docker-compose to see them in effect. This procedure is conducted many times in a normal software develpment lifecycle and in the long term it can be time-consuming and frustrating. I know that often development servers have auto reloading functionality out of the box if you mount the code instead of copying it in the docker container, however, I often find myself needing to have auto reload on commands that do not really have auto reloading. 
+You have a stack of a web proxy, web server and a database all together containerized
+and configured as services in docker-compose for easy deployment. To develop locally,
+you make the changes and run `docker-compose up` to inspect what has changed. You
+realise that you have do make additional changes but now you need to restart
+docker-compose to see them in effect. This procedure is conducted many times in a normal
+software develpment lifecycle and in the long term it can be time-consuming and
+frustrating. I know that often development servers have auto reloading functionality out
+of the box if you mount the code instead of copying it in the docker container, however,
+I often find myself needing to have auto reload on commands that do not really have auto
+reloading. 
 
-With the livereloader docker image you can easily instrument your docker compose service to be restarted when there are any new file modifications. What is more, the file watching is configurable such that you can control the delay to wait for reload and the patterns that reloading should react to (WIP).
+With the livereloader docker image you can easily instrument your docker compose service
+to be restarted when there are any new file modifications. What is more, the file
+watching is configurable such that you can control the delay to wait for reload and the
+patterns that reloading should react to (WIP).
 
-Follow the next sections to find more details about this and how to get started using it.
+Follow the next sections to find more details about this and how to get started using
+it.
 
 # Getting Started
 
-It is very simple to get started with the docker-compose live reloader. First things first, you need to have a docker compose file. The concept is to create a new local docker-compose file which extends your existing one and just adds one the reloader service to your stack. 
+It is very simple to get started with the docker-compose live reloader. First things
+first, you need to have a docker compose file. The concept is to create a new local
+docker-compose file which extends your existing one and just adds one the reloader
+service to your stack. 
 
-The reloading functionality was written as a separate container such that the changes required in order to get started using it are minimal. With this in mind, you can easily separate the local docker-compose files which contain live reloading from automatically deployed environments. 
+The reloading functionality was written as a separate container such that the changes
+required in order to get started using it are minimal. With this in mind, you can easily
+separate the local docker-compose files which contain live reloading from automatically
+deployed environments. 
 
 ## How to enable reloading
 
-1. Create a new docker-compose yaml file i.e. `docker-compose-with-reloading.yml` and add the following"
+1. Create a new docker-compose yaml file i.e. `docker-compose-with-reloading.yml` and
+   add the following"
 
 ```yml
 version: '3'
@@ -32,23 +53,35 @@ services:
         container_name: livereloader
         privileged: true
         environment:
-            - RELOAD_DELAY=<DELAY>              # seconds
             - RELOAD_CONTAINER=<CONTAINER_NAME>
-            - RELOAD_DIR=<DIR_TO_WATCH>
+            - RELOAD_LABEL=<A_DOCKER_CONTAINER_LABEL>
+            - RELOAD_DELAY=<DELAY>              # seconds
+            - RESTART_TIMEOUT=<TIMEOUT>         # seconds
+            - RELOAD_DIR=<DIRS_TO_WATCH>
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
             - "<SOURCE CODE DIR>:<DIRECTORY_TO_MOUNT_CODE>"
 ```
 
-Note that version 3 is only indicative, you can use your own docker compose version number.
+Note that version 3 is only indicative, you can use your own docker compose version
+number.
 
-The only required parameter in the above docker-compose service is the `RELOAD_CONTAINER` variable which is the name of the container to be reloaded. The other variables can be ommited. (More details in the Configuration section below)
+The only required parameters in the above docker-compose service are either the
+`RELOAD_CONTAINER` or the `RELOAD_LABEL` variables which give instructions of which
+containers are ought to be reloaded. The other variables can be ommited. (More details
+in the Configuration section below)
 
-In order for the reloading service to watch for changes you have to mount your source code directory to a directory in the container. If no `RELOAD_DIR` variable was set, livereloader automatically watches for changes in that directory. A more explicit path can be set with `RELOAD_DIR`
+In order for the reloading service to watch for changes you have to mount your source
+code directory to a directory in the container. If no `RELOAD_DIR` variable was set,
+livereloader automatically watches for changes in that directory. A more explicit path
+can be set with `RELOAD_DIR`
 
-2. Make sure that the service that you want to be reloaded has a container name that matches the `RELOAD_CONTAINER` environment variable of the reloader. Also ensure that code's directory is mounted to your service container as well. (If not mounted, reloading will work but code changes will not be applied to restarted container)
+1. Ensure that the code's directory is mounted to your service container as well. (If
+   not mounted, reloading will work but code changes will not be applied to restarted
+   container)
 
-Assuming that you don't have the source code mounted already and container name is differeny you can add the following in your new docker-compose file to override it.
+Assuming that you don't have the source code mounted already and container name is
+differently you can add the following in your new docker-compose file to override it.
 i.e:
 
 ```yml
@@ -101,6 +134,7 @@ version: '3'
 
 services:
   test-service:
+    image: ubuntu
     container_name: test-container-name  
 
   live-reloader:
@@ -122,11 +156,23 @@ docker-compose -f docker-compose.yml -f docker-compose-with-reloading.yml up
 
 # Reloading Configration 
 
-The reloading can be configured from the environment variables of the `livereloader` docker-compoe service. Here is a list of the available configuration variables:
+The reloading can be configured from the environment variables of the `livereloader`
+docker-compoe service. Here is a list of the available configuration variables:
 
-- **RELOAD_CONTAINER**: The container name to target for reloading. (Required: True)
-- **RELOAD_DELAY**: The number of seconds to wait before restarting the container (Required: False, Default: 1.5s)
-- **RELOAD_DIR**: The directory to monitor for changes. This is automatically derived from the mount directory in the livereloader service but in case you want to explicitly set it, this environment variable can be used. (Required: False, Default: \<Mount Directory in Docker-compose\>)
+- **RELOAD_CONTAINER**: The container name to target for reloading. (Required: False,
+  but this or **RELOAD_LABEL** must be set if any containers are to be restarted)
+- **RELOAD_LABEL**: A container label name.  All containers with that label name will be
+  restarted. (Required: False, but this or **RELOAD_CONTAINER** must be set if any
+  containers are to be restarted)
+- **RELOAD_DELAY**: The number of seconds to wait before restarting the container
+  (Required: False, Default: 1.5s)
+- **RESTART_TIMEOUT**: The timeout period in seconds to wait for the container to
+  restart. (Requied: False, Default: 10, same as the default timeout of Docker)
+- **RELOAD_DIR**: The directory or directories to monitor for changes (multiple
+  directories can be supplied, comma-separated). This can also be automatically derived
+  from the mount directory in the livereloader service but in case you want to
+  explicitly set it, this environment variable can be used.  (Required: False, Default:
+  \<Mount Directory in Docker-compose\>)
 
 # Contribute
 

--- a/test/docker-compose-with-reloading.yml
+++ b/test/docker-compose-with-reloading.yml
@@ -1,17 +1,54 @@
-version: '3'
+version: "3"
 
 services:
-  test-service:
-    container_name: test-container-name  
+  label1-service:
+    container_name: label1-service
+    labels:
+      - live-reload
+    image: ubuntu
+    volumes:
+      - ".:/code"
+    working_dir: "/code"
+    command: ./command.sh
+
+  label2-service:
+    container_name: label2-service
+    labels:
+      - live-reload
+    image: ubuntu
+    volumes:
+      - ".:/code"
+    working_dir: "/code"
+    command: ./command.sh
+
+  named-service:
+    container_name: named-service
+    labels:
+      - live-reload
+    image: ubuntu
+    volumes:
+      - ".:/code"
+    working_dir: "/code"
+    command: ./command.sh
+
+  not-reloading-service:
+    container_name: not-reloading-service
+    image: ubuntu
+    volumes:
+      - ".:/code"
+    working_dir: "/code"
+    command: ./command.sh
 
   live-reloader:
-    image: apogiatzis/livereloading
+    image: stratosgear/livereloading
     container_name: livereloader
     privileged: true
     environment:
-      - RELOAD_DELAY=1.5              # seconds
-      - RELOAD_CONTAINER=test-container-name
-      - RELOAD_DIR=/code
+      - RELOAD_DELAY=2 # seconds
+      - RELOAD_CONTAINER=named-service
+      # - RELOAD_DIRS=/code
+      - RESTART_TIMEOUT=1
+      - RELOAD_LABEL=live-reload
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
-      - ".:/code"
+      # - ".:/code"


### PR DESCRIPTION
Hi Andrea,

I'm not sure if you would like to merge this one.

It (greatly) enhances the functionality that you provide, by providing extra configuration parameters and enhancing the existing ones.

* It allows the user to supply docker labels, in order to mark mutliple containers that need reloading.
* It allows overriding the restart timeout (from the default 10 secs of Docker)
* It allows to pass comma-separated list of source code paths to monitor.

I'm scratching my own itch here, where I have multiple containers that need to be restarted automatically, and although your utility would perfectly deal with one container, it could not handle such a case.

I have tried and kept backwards compatibility with all previous configuration params, so this update should NOT be disruptive to existing users  (for example I would have liked  to rename the `RELOAD_DIR` configuration parameter to `RELOAD_DIRS` to better reflect that this could be a list of directories, but I didn't). You can see the update Readme file on my [fork](https://github.com/stratosgear/docker-compose-livereloader/tree/live_reload_on_labels)

Excuse my editor for applying a (much) different  python source code formatting (based on black) but I think the changes are clear enough.

I also fixed your test case that did not seem to work correctly.

As I think this is an improvement on the original design (αν δεν παινέψεις το σπίτι σου...) if you choose to not merge this, I would like to have your permission to post this on my github account, obviously with credit to your original work.  But I really do not think this needs to have a separate home.  Maybe we could be co-authors on this one!

I really look forward to see this live soon, as I said I got to really use this!

Thanks! Stay safe!
 