### PR TITLE
Option to use a polling observer by setting an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ services:
             - RELOAD_DELAY=<DELAY>              # seconds
             - RESTART_TIMEOUT=<TIMEOUT>         # seconds
             - RELOAD_DIR=<DIRS_TO_WATCH>
+            - OBSERVER_TYPE=<TYPE> 
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
             - "<SOURCE CODE DIR>:<DIRECTORY_TO_MOUNT_CODE>"
@@ -173,6 +174,13 @@ docker-compoe service. Here is a list of the available configuration variables:
   from the mount directory in the livereloader service but in case you want to
   explicitly set it, this environment variable can be used.  (Required: False, Default:
   \<Mount Directory in Docker-compose\>)
+- **OBSERVER_TYPE**: The type of observer to use. Supports two types: standard (0) and 
+  polling (1). Mounting your windows code directory into a linux container may cause 
+  the standard observer not to see changes made on the windows side ('inotify' is 
+  not triggered). The polling observer will trigger although at a slower pace. 
+  Another workaround suggests using the 'docker-windows-volume-watcher' package. 
+  (Required: False, Default: 0)
+
 
 # Contribute
 

--- a/src/reloader.py
+++ b/src/reloader.py
@@ -6,6 +6,8 @@ import time
 from os import environ
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+
 
 logging.basicConfig(
     format="%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s",
@@ -24,6 +26,7 @@ class Reloader(object):
         self.reload_delay = float(environ.get("RELOAD_DELAY", 1.5))
         self.restart_timeout = int(environ.get("RESTART_TIMEOUT", 10))
         self.reload_container = environ.get("RELOAD_CONTAINER")
+        self.observer_type = int(environ.get("OBSERVER_TYPE",0))
 
     def event_handler_factory(
         self, *args, patterns=["*"], ignore_directories=True, **kwargs
@@ -121,7 +124,12 @@ class Reloader(object):
         """
         Runs watchdog process to monitor file changes and reload container
         """
-        observer = Observer()
+
+        if self.observer_type == 0:
+            observer = Observer()
+        elif self.observer_type == 1:
+            observer = PollingObserver()
+
         if self.reload_dirs:
             for a_dir in self.reload_dirs:
                 observer.schedule(self.event_handler_factory(), a_dir, recursive=True)

--- a/test/docker-compose-with-reloading.yml
+++ b/test/docker-compose-with-reloading.yml
@@ -49,6 +49,7 @@ services:
       # - RELOAD_DIRS=/code
       - RESTART_TIMEOUT=1
       - RELOAD_LABEL=live-reload
+      - OBSERVER_TYPE=0 # standard = 0, polling = 1
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       # - ".:/code"


### PR DESCRIPTION
As suggested in the discussion for issue #6. The current observer does not work when using a windows host and linux container. Using a poller observer is a fix that works good for me.

I am tottaly open for suggestions. I am quite new to docker, found this repo while setting up a python project. With this small change it is a huge time saver for me while debugging. Great work!