### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.10
 
 RUN apt-get -y update && apt -y install docker.io && curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose
 


### PR DESCRIPTION
Not only will this bring the image up to the current Python version,
but it will also provide compatability with the Apple M1 chips.